### PR TITLE
disable building pybind11 tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ macro(build_pybind11)
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
+      -DPYBIND11_TEST=OFF
       ${extra_cmake_args}
   )
 


### PR DESCRIPTION
There's a whole bunch of warnings coming when compiling the tests. In order to avoid them and to speed up the compilation process, I think it makes sense to disable the tests.