### PR TITLE
Upgrade to pybind11 v2.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,8 @@ macro(build_pybind11)
 
   include(ExternalProject)
   ExternalProject_Add(pybind11-2.5.0
-    URL https://github.com/pybind/pybind11/archive/v2.5.0.tar.gz
-    URL_MD5 1ad2c611378fb440e8550a7eb6b31b89
+    URL https://github.com/pybind/pybind11/archive/v2.6.0.tar.gz
+    URL_MD5 6815d191e63c5be21c3630b268688eb8
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install


### PR DESCRIPTION
Resolves #6 

The only core package depending on pybind11, at the moment, is `rosbag2_py`. Running CI up `rosbag2_py` and testing `rosbag2_py`:

* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12845)](https://ci.ros2.org/job/ci_linux/12845/)
* Linux-aarch64 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7799)](https://ci.ros2.org/job/ci_linux-aarch64/7799/)
* macOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10556)](https://ci.ros2.org/job/ci_osx/10556/)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12788)](https://ci.ros2.org/job/ci_windows/12788/)
* Windows Debug: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12789)](https://ci.ros2.org/job/ci_windows/12789/)

EDIT: re-triggered CI with changes in ros2/rosbag2#544