### PR TITLE
Update pybind11 to 2.7.1.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,14 @@ project(pybind11_vendor)
 
 find_package(ament_cmake REQUIRED)
 
+option(FORCE_BUILD_VENDOR_PKG
+  "Build pybind11 from source, even if system-installed package is available"
+  OFF)
+
+if(NOT FORCE_BUILD_VENDOR_PKG)
+  find_package(pybind11 QUIET)
+endif()
+
 macro(build_pybind11)
   set(extra_cmake_args)
 
@@ -46,9 +54,9 @@ macro(build_pybind11)
 
 
   include(ExternalProject)
-  ExternalProject_Add(pybind11-2.5.0
-    URL https://github.com/pybind/pybind11/archive/v2.5.0.tar.gz
-    URL_MD5 1ad2c611378fb440e8550a7eb6b31b89
+  ExternalProject_Add(pybind11-2.7.1
+    URL https://github.com/pybind/pybind11/archive/v2.7.1.tar.gz
+    URL_MD5 b87860218c143728f8e6efa6cba7e1ed
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
@@ -66,8 +74,8 @@ macro(build_pybind11)
   )
 endmacro()
 
-# Currently, always build.
-# This could be improved with logic to use installed platform packages.
-build_pybind11()
+if(NOT pybind11_FOUND)
+  build_pybind11()
+endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,16 +52,28 @@ macro(build_pybind11)
   endif()
   list(APPEND extra_cmake_args "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
-
   include(ExternalProject)
   ExternalProject_Add(pybind11-2.7.1
-    URL https://github.com/pybind/pybind11/archive/v2.7.1.tar.gz
-    URL_MD5 b87860218c143728f8e6efa6cba7e1ed
-    TIMEOUT 600
+    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+    GIT_TAG v2.7.1
+    GIT_CONFIG advice.detachedHead=false
+    # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
+    # See https://github.com/ament/uncrustify_vendor/pull/22 for details
+    UPDATE_COMMAND ""
+    TIMEOUT 300
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
       -DPYBIND11_TEST=OFF
       ${extra_cmake_args}
+    # By default, pybind11 sets Py_DEBUG if the interpreter is a debug one (as
+    # it is in Windows Debug).  Unfortunately, this conflicts with Py_DEBUG as
+    # used by the CPython headers, and ultimately ends up causing multiple
+    # definitions for Py_DEBUG, which MSVC complains about.  This patch switches
+    # the internal pybind11 variable to be called PYBIND11_DEBUG, which avoids
+    # the issue.
+    PATCH_COMMAND
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn
+        ${CMAKE_CURRENT_SOURCE_DIR}/pybind11-2.7.1-fix-windows-debug.patch
   )
 
   # The external project will install to the build folder, but we'll install that on make install.

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>pybind11-dev</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/pybind11-2.7.1-fix-windows-debug.patch
+++ b/pybind11-2.7.1-fix-windows-debug.patch
@@ -1,0 +1,33 @@
+--- a/tools/pybind11Tools.cmake	2022-01-05 20:09:58.470396082 +0000
++++ b/tools/pybind11Tools.cmake	2022-01-05 20:10:09.967351988 +0000
+@@ -113,7 +113,7 @@ if(PYTHON_IS_DEBUG)
+   set_property(
+     TARGET pybind11::pybind11
+     APPEND
+-    PROPERTY INTERFACE_COMPILE_DEFINITIONS Py_DEBUG)
++    PROPERTY INTERFACE_COMPILE_DEFINITIONS PYBIND11_DEBUG)
+ endif()
+ 
+ set_property(
+--- a/tools/pybind11NewTools.cmake	2022-01-05 20:10:04.286373776 +0000
++++ b/tools/pybind11NewTools.cmake	2022-01-05 20:10:30.186274440 +0000
+@@ -123,7 +123,7 @@ if(PYTHON_IS_DEBUG)
+   set_property(
+     TARGET pybind11::pybind11
+     APPEND
+-    PROPERTY INTERFACE_COMPILE_DEFINITIONS Py_DEBUG)
++    PROPERTY INTERFACE_COMPILE_DEFINITIONS PYBIND11_DEBUG)
+ endif()
+ 
+ # Check on every access - since Python2 and Python3 could have been used - do nothing in that case.
+--- a/include/pybind11/detail/common.h	2022-01-05 20:08:54.029643196 +0000
++++ b/include/pybind11/detail/common.h	2022-01-05 20:09:12.178573603 +0000
+@@ -137,7 +137,7 @@
+ #  pragma warning(push)
+ // C4505: 'PySlice_GetIndicesEx': unreferenced local function has been removed (PyPy only)
+ #  pragma warning(disable: 4505)
+-#  if defined(_DEBUG) && !defined(Py_DEBUG)
++#  if defined(_DEBUG) && !defined(PYBIND11_DEBUG)
+ #    define PYBIND11_DEBUG_MARKER
+ #    undef _DEBUG
+ #  endif

--- a/pybind11-2.7.1-fix-windows-debug.patch
+++ b/pybind11-2.7.1-fix-windows-debug.patch
@@ -31,3 +31,20 @@
  #    define PYBIND11_DEBUG_MARKER
  #    undef _DEBUG
  #  endif
+--- a/CMakeLists.txt	2022-01-06 14:02:51.005506594 +0000
++++ b/CMakeLists.txt	2022-01-06 14:08:09.755079249 +0000
+@@ -16,6 +16,14 @@ else()
+   cmake_policy(VERSION 3.18)
+ endif()
+ 
++# In CMake version 3.22 or above, cmake_dependent_option now supports Full Condition Syntax
++# (see https://cmake.org/cmake/help/latest/module/CMakeDependentOption.html).
++# Unfortunately, the detection of what needs to be escaped seems to be buggy, so we
++# disable this warning for now.
++if(${CMAKE_VERSION} VERSION_GREATER 3.22)
++  cmake_policy(SET CMP0127 OLD)
++endif()
++
+ # Extract project version from source
+ file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/include/pybind11/detail/common.h"
+      pybind11_version_defines REGEX "#define PYBIND11_VERSION_(MAJOR|MINOR|PATCH) ")


### PR DESCRIPTION
This is the version that is shipped in Ubuntu 22.04.
While we are in here, also make it so we only build pybind11
if we need it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Still in draft because I'm pretty sure we need some other PRs to go along with this, and I haven't tested on Windows or Windows Debug yet.