### PR TITLE
Force pybind11 to find Python 3.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,4 +91,4 @@ if(NOT pybind11_FOUND)
   build_pybind11()
 endif()
 
-ament_package()
+ament_package(CONFIG_EXTRAS_POST "${PROJECT_NAME}-extras.cmake")

--- a/pybind11_vendor-extras.cmake
+++ b/pybind11_vendor-extras.cmake
@@ -1,0 +1,3 @@
+# Force the PYBIND11_PYTHON_VERSION to "3", which helps pybind11 find the
+# correct version when both Python 2 and Python 3 libraries are installed.
+set(PYBIND11_PYTHON_VERSION "3")


### PR DESCRIPTION
We've had sporadic reports of failures to build rclpy because it can't find Python.h.  It turns out that the problem is that, by default, pybind11 seems to prefer the Python 2 set of libraries if the development packages are installed.

This change adds in a CMake extras file that forces pybind11 to always choose Python 3, even if the Python 2 development libraries are available.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>