### PR TITLE
Add a modified patch from upstream to support Python 3.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,9 @@ macro(build_pybind11)
     PATCH_COMMAND
       ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn
         ${CMAKE_CURRENT_SOURCE_DIR}/pybind11-2.9.1-fix-windows-debug.patch
+    COMMAND
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn
+        ${CMAKE_CURRENT_SOURCE_DIR}/pybind11-python-3.11.patch
   )
 
   # The external project will install to the build folder, but we'll install that on make install.

--- a/pybind11-python-3.11.patch
+++ b/pybind11-python-3.11.patch
@@ -1,0 +1,114 @@
+From 42a8e3125348d4e706e46eb410befc1422d42b3f Mon Sep 17 00:00:00 2001
+From: Aaron Gokaslan <skylion.aaron@gmail.com>
+Date: Wed, 2 Mar 2022 13:17:52 -0500
+Subject: [PATCH] Improve Python 3.11 support (#3694)
+
+* Test out Python 3.11 migration
+
+* Clean up a bit
+
+* Remove todo
+
+* Test workaround
+
+* Fix potential bug uncovered in 3.11
+
+* Try to fix it more
+
+* last ditch fix
+
+* Revert. Tp-traverse isn't the problem
+
+* Test workaround
+
+* Try this hack
+
+* Revert MRO changes
+
+* Use f_back properly
+
+* Qualify auto
+
+* Update include/pybind11/pybind11.h
+
+* [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+for more information, see https://pre-commit.ci
+
+* Simplify code slightly
+
+* Ensure co_varnames decref if dict_getitem throws
+
+* Eager decref f_code
+
+Co-authored-by: Henry Schreiner <HenrySchreinerIII@gmail.com>
+Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+---
+ include/pybind11/detail/type_caster_base.h | 12 ++++++++++--
+ include/pybind11/pybind11.h                | 12 ++++++------
+ 2 files changed, 16 insertions(+), 8 deletions(-)
+
+diff --git a/include/pybind11/detail/type_caster_base.h b/include/pybind11/detail/type_caster_base.h
+index ff7d7cf8c2..a4154136a6 100644
+--- a/include/pybind11/detail/type_caster_base.h
++++ b/include/pybind11/detail/type_caster_base.h
+@@ -466,9 +466,10 @@ PYBIND11_NOINLINE std::string error_string() {
+             trace = trace->tb_next;
+ 
+         PyFrameObject *frame = trace->tb_frame;
++        Py_XINCREF(frame);
+         errorString += "\n\nAt:\n";
+         while (frame) {
+-#if PY_VERSION_HEX >= 0x03090000
++#if PY_VERSION_HEX >= 0x030900B1
+             PyCodeObject *f_code = PyFrame_GetCode(frame);
+ #else
+             PyCodeObject *f_code = frame->f_code;
+@@ -479,8 +480,15 @@ PYBIND11_NOINLINE std::string error_string() {
+                 "  " + handle(f_code->co_filename).cast<std::string>() +
+                 "(" + std::to_string(lineno) + "): " +
+                 handle(f_code->co_name).cast<std::string>() + "\n";
+-            frame = frame->f_back;
+             Py_DECREF(f_code);
++#    if PY_VERSION_HEX >= 0x030900B1
++            auto *b_frame = PyFrame_GetBack(frame);
++#    else
++            auto *b_frame = frame->f_back;
++            Py_XINCREF(b_frame);
++#    endif
++            Py_DECREF(frame);
++            frame = b_frame;
+         }
+     }
+ #endif
+diff --git a/include/pybind11/pybind11.h b/include/pybind11/pybind11.h
+index 1ec6c17c67..4f6b2cdf41 100644
+--- a/include/pybind11/pybind11.h
++++ b/include/pybind11/pybind11.h
+@@ -2384,9 +2384,7 @@ inline function get_type_override(const void *this_ptr, const type_info *this_ty
+ 
+     /* Don't call dispatch code if invoked from overridden function.
+        Unfortunately this doesn't work on PyPy. */
+-#if !defined(PYPY_VERSION) && PY_VERSION_HEX < 0x030B0000
+-    // TODO: Remove PyPy workaround for Python 3.11.
+-    // Current API fails on 3.11 since co_varnames can be null.
++#if !defined(PYPY_VERSION)
+ #if PY_VERSION_HEX >= 0x03090000
+     PyFrameObject *frame = PyThreadState_GetFrame(PyThreadState_Get());
+     if (frame != nullptr) {
+@@ -2394,10 +2392,11 @@ inline function get_type_override(const void *this_ptr, const type_info *this_ty
+         // f_code is guaranteed to not be NULL
+         if ((std::string) str(f_code->co_name) == name && f_code->co_argcount > 0) {
+             PyObject* locals = PyEval_GetLocals();
+-            if (locals != nullptr && f_code->co_varnames != nullptr) {
+-                PyObject *self_caller = dict_getitem(
+-                    locals, PyTuple_GET_ITEM(f_code->co_varnames, 0)
+-                );
++            if (locals != nullptr) {
++                PyObject *co_varnames = PyObject_GetAttrString((PyObject *) f_code, "co_varnames");
++                PyObject *self_arg = PyTuple_GET_ITEM(co_varnames, 0);
++                Py_DECREF(co_varnames);
++                PyObject *self_caller = dict_getitem(locals, self_arg);
+                 if (self_caller == self.ptr()) {
+                     Py_DECREF(f_code);
+                     Py_DECREF(frame);


### PR DESCRIPTION
This patch was released in pybind11 version 2.10 and is necessary to build against Python 3.11.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=18147)](http://ci.ros2.org/job/ci_linux/18147/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=12685)](http://ci.ros2.org/job/ci_linux-aarch64/12685/)
* Linux-rhel8 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=334)](https://ci.ros2.org/job/ci_linux-rhel/334/)
* Linux-rhel9 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=335)](https://ci.ros2.org/job/ci_linux-rhel/335/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=18804)](http://ci.ros2.org/job/ci_windows/18804/)